### PR TITLE
Fixed issue with formatting log messages post encryption

### DIFF
--- a/src/zato/enclog/_core.py
+++ b/src/zato/enclog/_core.py
@@ -52,6 +52,14 @@ class EncryptedLogFormatter(Formatter):
         if isinstance(msg, str):
             msg = msg.encode('utf8')
         record.msg = '{}{}'.format(log_prefix, self.fernet.encrypt(msg).decode('utf8'))
+        # record.getMessage() above already formats the complete message
+        # using the required record.args. Once encrypted there is no use
+        # for the record.args. Hence we set it to None.
+        # This is necessary to allow logs of the following kind  
+        # logging.info("Log: %s", some_string)
+        # If we do not set record.args to None, we would get exceptions such as
+        # "TypeError: not all arguments converted during string formatting"        
+        record.args = None
         return super(EncryptedLogFormatter, self).format(record)
 
 # ################################################################################################################################


### PR DESCRIPTION
This fix allows for logs of kind `logging.info("Log: %s", some_string)`, without throwing exceptions like,
`TypeError: not all arguments converted during string formatting.`

For more details see https://github.com/zatosource/zato-enclog/issues/1